### PR TITLE
Changed copy on the confirmation page

### DIFF
--- a/src/components/booking/complete.component.nghtml
+++ b/src/components/booking/complete.component.nghtml
@@ -6,7 +6,7 @@
   <div class="booking-confirmation-message">
     <h3>Hello {{ order.customer().firstName }}, you are all set!</h3>
     <p ng-if='product.postTransactionalMessage'>{{ product.postTransactionalMessage }}</p>
-    <p ng-if='!product.postTransactionalMessage'>Thank you for scheduling your consultation!</p>
+    <p ng-if='!product.postTransactionalMessage'>Thanks for booking with us!</p>
   </div>
   <hr />
   <div class="booking-confirmation-note">


### PR DESCRIPTION
Since we have customers using it not just for "consultation" -- the message "thank you for booking your consultation" has been changed to a more generic message.